### PR TITLE
Add control configuuration of homepage button URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Docdash supports the following options:
         scopeInOutputPath: [false|true], // Add scope from package file (if present) to the output path, true by default.
         nameInOutputPath: [false|true], // Add name from package file to the output path, true by default.
         versionInOutputPath: [false|true] // Add package version to the output path, true by default. 
-    }
+    },
+    "home": "index.html" // Control the URL of the home button
 }
 ```
 

--- a/publish.js
+++ b/publish.js
@@ -426,7 +426,8 @@ function linktoExternal(longName, name) {
  */
 
 function buildNav(members) {
-    var nav = '<h2><a href="index.html">Home</a></h2>';
+    var href = env.conf.docdash.home || 'index.html'
+    var nav = '<h2><a href="' + href + '">Home</a></h2>';
     var seen = {};
     var seenTutorials = {};
     var docdash = env && env.conf && env.conf.docdash || {};


### PR DESCRIPTION
The document directory is not in the root directory of the static service I started.
It cannot be used normally when i go to the home page.

@example
url: http://localhost:8000/mydocs/
goto: http://localhost:8000/mydocs

so i want a configuration that can be modified directly.